### PR TITLE
⚡ Fix missing await in sleepsummary handler

### DIFF
--- a/NancyExample/Modules/IndexModule.cs
+++ b/NancyExample/Modules/IndexModule.cs
@@ -68,10 +68,10 @@ namespace NancyExample.Modules
                 return new JsonResponse(activity, new DefaultJsonSerializer());
             };
 
-            Get["api/withings/sleepsummary"] = nothing =>
+            Get["api/withings/sleepsummary", true] = async (nothing, ct) =>
             {
                 var client = new WithingsClient(_credentials);
-                var activity = client.GetSleepSummary
+                var activity = await client.GetSleepSummary
                 (
                     "2017-01-01",
                     "2017-03-30",


### PR DESCRIPTION
💡 **What:**
Converted the `api/withings/sleepsummary` handler in `NancyExample/Modules/IndexModule.cs` from a synchronous handler to an asynchronous one.

🎯 **Why:**
The previous implementation called `client.GetSleepSummary`, which returns a `Task<ExpandoObject>`, but did not await it. This resulted in the `Task` object itself being passed to `JsonResponse` and serialized, rather than the actual sleep summary data. This is a functional bug and a performance issue (returning incorrect data).

📊 **Measured Improvement:**
Verified using a reproduction script that simulating the old behavior results in a `JsonSerializationException` (self-referencing loop) or incorrect JSON output (Task properties). The new behavior correctly awaits the result and serializes the `ExpandoObject` data.


---
*PR created automatically by Jules for task [14018162645710599168](https://jules.google.com/task/14018162645710599168) started by @antarr*