### PR TITLE
⚡ Fix missing await in api/withings/body handler

### DIFF
--- a/NancyExample/Modules/IndexModule.cs
+++ b/NancyExample/Modules/IndexModule.cs
@@ -108,10 +108,10 @@ namespace NancyExample.Modules
                 return new JsonResponse(activity, new DefaultJsonSerializer());
             };
 
-            Get["api/withings/body"] = nothing =>
+            Get["api/withings/body", true] = async (nothing, ctx) =>
             {
                 var client = new WithingsClient(_credentials);
-                var activity = client.GetBodyMeasures
+                var activity = await client.GetBodyMeasures
                 (
                     ConfigurationManager.AppSettings["UserId"],
                     DateTime.Parse("2017-05-08"),


### PR DESCRIPTION
💡 **What:**
- Changed `Get["api/withings/body"]` to `Get["api/withings/body", true]` to enable async processing in Nancy.
- Updated the lambda to be `async (nothing, ctx)`.
- Added `await` to the `client.GetBodyMeasures(...)` call.

🎯 **Why:**
- **Correctness:** The previous code was returning a serialized `Task` object (e.g., `{"Id":1, "Status":5...}`) instead of the actual body measures data.
- **Performance:** Using `async/await` prevents thread blocking while waiting for the Withings API response, improving scalability and resource usage compared to a blocking synchronous call (had we just used `.Result`).

📊 **Measured Improvement:**
- **Baseline (Simulated):** Returning a Task object results in incorrect data types (Task State Machine).
- **Optimization:** Correctly awaits the task, returning the expected `ExpandoObject` JSON. This is primarily a correctness fix that leverages async I/O for performance.

---
*PR created automatically by Jules for task [9197853472210185529](https://jules.google.com/task/9197853472210185529) started by @antarr*