### PR TITLE
⚡ Fix missing await in sleepmeasures handler

### DIFF
--- a/NancyExample/Modules/IndexModule.cs
+++ b/NancyExample/Modules/IndexModule.cs
@@ -94,10 +94,10 @@ namespace NancyExample.Modules
                 return new JsonResponse(activity, new DefaultJsonSerializer());
             };
 
-            Get["api/withings/sleepmeasures"] = nothing =>
+            Get["api/withings/sleepmeasures", true] = async (nothing, ct) =>
             {
                 var client = new WithingsClient(_credentials);
-                var activity = client.GetSleepMeasures
+                var activity = await client.GetSleepMeasures
                 (
                     ConfigurationManager.AppSettings["UserId"],
                     DateTime.Now.AddDays(-90),


### PR DESCRIPTION
Converted the synchronous `api/withings/sleepmeasures` handler to be asynchronous. This fixes a correctness issue where the `Task` object was being returned and serialized instead of the actual sleep measures data. This also improves application responsiveness by freeing up the request thread while waiting for the Withings API response.

---
*PR created automatically by Jules for task [9476380193153711431](https://jules.google.com/task/9476380193153711431) started by @antarr*