### PR TITLE
⚡ Remove unused field _credentials in WithingsClient

### DIFF
--- a/Withings.NET/Client/WithingsClient.cs
+++ b/Withings.NET/Client/WithingsClient.cs
@@ -12,13 +12,11 @@ namespace Withings.NET.Client
 {
     public class WithingsClient
     {
-        readonly WithingsCredentials _credentials;
         const string BaseUri = "https://wbsapi.withings.net/v2";
         readonly ISerializer _serializer;
 
         public WithingsClient(WithingsCredentials credentials)
         {
-            _credentials = credentials;
             // Enable case-insensitive property name handling for strongly-typed models.
             // Note: ExpandoObjectConverter ignores PropertyNameCaseInsensitive and always
             // uses the JSON property names as-is when creating ExpandoObject keys.


### PR DESCRIPTION
This change removes the unused private field `_credentials` from the `WithingsClient` class.
- The declaration of `readonly WithingsCredentials _credentials;` was removed.
- The assignment `_credentials = credentials;` in the constructor was removed.
- The constructor signature `public WithingsClient(WithingsCredentials credentials)` was preserved to maintain backward compatibility with existing library consumers.
- Build artifacts and temporary log files were cleaned up.
- Code review was performed and confirmed the safety and correctness of the change.

---
*PR created automatically by Jules for task [6808538017947176428](https://jules.google.com/task/6808538017947176428) started by @antarr*