### PR TITLE
🧪 [testing] Add error handling tests for ExpandoObjectConverter

### DIFF
--- a/Withings.Specifications/ExpandoObjectConverterTests.cs
+++ b/Withings.Specifications/ExpandoObjectConverterTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Dynamic;
+using System.Text.Json;
+using FluentAssertions;
+using NUnit.Framework;
+using Withings.NET.Client;
+
+namespace Withings.Specifications
+{
+    [TestFixture]
+    public class ExpandoObjectConverterTests
+    {
+        private JsonSerializerOptions _options;
+
+        [SetUp]
+        public void Setup()
+        {
+            _options = new JsonSerializerOptions();
+            _options.Converters.Add(new ExpandoObjectConverter());
+        }
+
+        [Test]
+        public void Read_ValidJson_ReturnsExpandoObject()
+        {
+            // Arrange
+            var json = "{\"name\": \"John\", \"age\": 30, \"isDeveloper\": true}";
+
+            // Act
+            var result = JsonSerializer.Deserialize<ExpandoObject>(json, _options);
+
+            // Assert
+            result.Should().NotBeNull();
+            ((dynamic)result).name.Should().Be("John");
+            ((dynamic)result).age.Should().Be(30);
+            ((dynamic)result).isDeveloper.Should().Be(true);
+        }
+
+        [Test]
+        public void Read_NonObjectJson_ThrowsJsonException()
+        {
+            // Arrange
+            var json = "[1, 2, 3]";
+
+            // Act
+            Action act = () => JsonSerializer.Deserialize<ExpandoObject>(json, _options);
+
+            // Assert
+            act.Should().Throw<JsonException>();
+        }
+
+        [Test]
+        public void Read_UnexpectedTokenInObject_ThrowsJsonException()
+        {
+            // Line 24: if (reader.TokenType != JsonTokenType.PropertyName) throw new JsonException();
+            // This is inside a 'while (reader.Read())' loop that starts after a '{'.
+            // To hit this, we need the next token to be something other than EndObject or PropertyName.
+            // In a valid JSON object, after '{' or after a 'value,', the next token MUST be PropertyName or '}'.
+            // If it's something else (like '[' or '{' without a property name), it's invalid JSON.
+
+            // Example: "{[" is invalid. System.Text.Json might catch this before calling the converter
+            // if it validates the structure during Read().
+
+            var json = "{\"prop\": \"val\", [\"invalid\"]}";
+
+            Action act = () => JsonSerializer.Deserialize<ExpandoObject>(json, _options);
+            act.Should().Throw<JsonException>();
+        }
+
+        [Test]
+        public void Read_IncompleteObject_ThrowsJsonException()
+        {
+            // This targets the throw at the end of the while loop (line 30):
+            // throw new JsonException();
+            // which is reached if reader.Read() returns false before reaching EndObject.
+            var json = "{\"prop\": \"val\""; // Missing closing brace
+
+            Action act = () => JsonSerializer.Deserialize<ExpandoObject>(json, _options);
+            act.Should().Throw<JsonException>();
+        }
+    }
+}


### PR DESCRIPTION
This PR addresses a testing gap in `Withings.NET/Client/ExpandoObjectConverter.cs` by adding unit tests for invalid JSON scenarios.

🎯 **What:** The testing gap addressed is the missing validation for unexpected tokens and incomplete JSON objects during deserialization into an `ExpandoObject`.
📊 **Coverage:** 
- `Read_ValidJson_ReturnsExpandoObject`: Verifies happy path.
- `Read_NonObjectJson_ThrowsJsonException`: Verifies that the converter correctly rejects JSON that does not start with an object.
- `Read_UnexpectedTokenInObject_ThrowsJsonException`: Specifically targets the logic that expects a property name or end of object after starting an object.
- `Read_IncompleteObject_ThrowsJsonException`: Verifies handling of truncated JSON.
✨ **Result:** Increased test coverage and improved reliability of the JSON deserialization logic.

---
*PR created automatically by Jules for task [13520774752360079947](https://jules.google.com/task/13520774752360079947) started by @antarr*