### PR TITLE
🔒 Fix API Error Detail Exposure in Exceptions

### DIFF
--- a/Withings.NET/Client/Authenticator.cs
+++ b/Withings.NET/Client/Authenticator.cs
@@ -58,7 +58,7 @@ namespace Withings.NET.Client
 
             if (response.Status != 0)
             {
-                 throw new Exception($"Withings API Error: {response.Status} - {response.Error}");
+                 throw new Exception($"Withings API Error: {response.Status}");
             }
 
             return response.Body;
@@ -82,7 +82,7 @@ namespace Withings.NET.Client
 
             if (response.Status != 0)
             {
-                 throw new Exception($"Withings API Error: {response.Status} - {response.Error}");
+                 throw new Exception($"Withings API Error: {response.Status}");
             }
 
             return response.Body;

--- a/Withings.Specifications/AuthenticatorSecurityTests.cs
+++ b/Withings.Specifications/AuthenticatorSecurityTests.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Threading.Tasks;
+using Flurl.Http.Testing;
+using NUnit.Framework;
+using Withings.NET.Client;
+using Withings.NET.Models;
+using FluentAssertions;
+
+namespace Withings.Specifications
+{
+    [TestFixture]
+    public class AuthenticatorSecurityTests
+    {
+        private Authenticator _authenticator;
+        private HttpTest _httpTest;
+
+        [SetUp]
+        public void Setup()
+        {
+            _httpTest = new HttpTest();
+            var credentials = new WithingsCredentials();
+            credentials.SetConsumerProperties("client_id", "client_secret");
+            credentials.SetCallbackUrl("http://localhost");
+            _authenticator = new Authenticator(credentials);
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            _httpTest.Dispose();
+        }
+
+        [Test]
+        public async Task GetAccessToken_Should_Not_Expose_Error_Detail_In_Exception()
+        {
+            // Arrange
+            _httpTest.RespondWithJson(new
+            {
+                status = 401,
+                error = "This is a sensitive error message that should not be exposed"
+            });
+
+            // Act
+            Func<Task> act = async () => await _authenticator.GetAccessToken("code");
+
+            // Assert
+            var exception = await act.Should().ThrowAsync<Exception>();
+            exception.WithMessage("*401*");
+            exception.WithMessage("*Withings API Error*");
+            exception.Which.Message.Should().NotContain("This is a sensitive error message");
+        }
+
+        [Test]
+        public async Task RefreshAccessToken_Should_Not_Expose_Error_Detail_In_Exception()
+        {
+            // Arrange
+            _httpTest.RespondWithJson(new
+            {
+                status = 401,
+                error = "This is another sensitive error message that should not be exposed"
+            });
+
+            // Act
+            Func<Task> act = async () => await _authenticator.RefreshAccessToken("refresh_token");
+
+            // Assert
+            var exception = await act.Should().ThrowAsync<Exception>();
+            exception.WithMessage("*401*");
+            exception.WithMessage("*Withings API Error*");
+            exception.Which.Message.Should().NotContain("This is another sensitive error message");
+        }
+    }
+}


### PR DESCRIPTION
🎯 **What:** This PR fixes a security vulnerability in `Withings.NET/Client/Authenticator.cs` where raw error details from the Withings API were being included in exception messages thrown during the access token and refresh token flows.

⚠️ **Risk:** Including raw API error messages in exceptions can lead to **Information Exposure through Error Messages (CWE-209)**. These error strings might contain sensitive data such as tokens, internal IDs, or other system information that should not be exposed to the application using the library.

🛡️ **Solution:** The fix normalizes the exception message to only include the numeric API status code. This provides sufficient information to categorize the error while ensuring that the detailed error string from the API provider is not leaked.

✅ **Verification:**
- Added a new test file `Withings.Specifications/AuthenticatorSecurityTests.cs` using `Flurl.Http.Testing` to mock API error responses and verify that the resulting exception message does not contain the sensitive error detail.
- The changes were reviewed and confirmed to address the vulnerability without introducing regressions.

---
*PR created automatically by Jules for task [14022795909644896913](https://jules.google.com/task/14022795909644896913) started by @antarr*