### PR TITLE
🧪 Add error path test for RefreshAccessToken

### DIFF
--- a/Withings.Specifications/AuthenticatorTests.cs
+++ b/Withings.Specifications/AuthenticatorTests.cs
@@ -42,5 +42,11 @@ namespace Withings.Specifications
         {
             Assert.ThrowsAsync<WithingsApiException>(async () => await _authenticator.GetAccessToken("invalid_code"));
         }
+
+        [Test]
+        public void InvalidRefreshRequestForAccessToken()
+        {
+            Assert.ThrowsAsync<WithingsApiException>(async () => await _authenticator.RefreshAccessToken("invalid_refresh_token"));
+        }
     }
 }


### PR DESCRIPTION
This PR adds a missing error path test for the RefreshAccessToken method in the Authenticator class, ensuring it correctly throws a WithingsApiException when the API returns a non-zero status code. This improves test coverage by matching the existing error path test for GetAccessToken.

---
*PR created automatically by Jules for task [2933226300214382473](https://jules.google.com/task/2933226300214382473) started by @antarr*