### PR TITLE
🧹 Remove unused using directives in models

### DIFF
--- a/Withings.NET/Models/Measuregrp.cs
+++ b/Withings.NET/Models/Measuregrp.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Runtime.Serialization;
 
 namespace Withings.NET.Models
 {

--- a/Withings.NET/Models/WithingsBody.cs
+++ b/Withings.NET/Models/WithingsBody.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Runtime.Serialization;
 
 namespace Withings.NET.Models
 {


### PR DESCRIPTION
🎯 **What:** Removed unused `using System.Runtime.Serialization;` directives from `Measuregrp.cs` and `WithingsBody.cs`.
💡 **Why:** These directives were not used (no `DataContract` or `DataMember` attributes present), and removing them improves code maintainability and readability.
✅ **Verification:** Verified that the project builds and all unit tests pass on .NET 8.0 and .NET 10.0.
✨ **Result:** Cleaner codebase with reduced noise in model files.

---
*PR created automatically by Jules for task [12050682321863584092](https://jules.google.com/task/12050682321863584092) started by @antarr*