### PR TITLE
🔒 Secure web server binding and enforce HTTPS

### DIFF
--- a/Withings.Example/Program.cs
+++ b/Withings.Example/Program.cs
@@ -37,6 +37,7 @@ builder.Services.AddSingleton<WithingsClient>();
 
 var app = builder.Build();
 
+app.UseHttpsRedirection();
 app.UseSession();
 
 app.MapGet("/", () => Results.Redirect("/api/oauth/authorize", permanent: true));
@@ -201,4 +202,4 @@ app.MapGet("/api/withings/intraday", async (HttpContext context, WithingsClient 
     return Results.Json(activity);
 });
 
-app.Run("http://0.0.0.0:8080");
+app.Run();

--- a/Withings.Example/appsettings.json
+++ b/Withings.Example/appsettings.json
@@ -1,0 +1,12 @@
+{
+  "Kestrel": {
+    "Endpoints": {
+      "Http": {
+        "Url": "http://127.0.0.1:8080"
+      },
+      "Https": {
+        "Url": "https://127.0.0.1:8081"
+      }
+    }
+  }
+}


### PR DESCRIPTION
🎯 **What:** This PR fixes a security vulnerability where the web server was hardcoded to bind to an insecure HTTP endpoint on all network interfaces (`0.0.0.0:8080`).

⚠️ **Risk:** Binding to all interfaces without encryption exposes the application (and sensitive OAuth tokens handled in callbacks) to potential interception or unauthorized access on the local network.

🛡️ **Solution:**
- Updated `Program.cs` to use `app.Run()` without hardcoded arguments, allowing for external configuration.
- Added `app.UseHttpsRedirection()` to the middleware pipeline to ensure all traffic is upgraded to HTTPS.
- Created an `appsettings.json` file for `Withings.Example` that provides secure defaults, binding only to the local loopback interface (`127.0.0.1`) and defining both HTTP and HTTPS endpoints.

---
*PR created automatically by Jules for task [4250520528762780999](https://jules.google.com/task/4250520528762780999) started by @antarr*