### PR TITLE
⚡ Performance Optimization: Cache JsonSerializerOptions in WithingsClient

### DIFF
--- a/Withings.NET/Client/WithingsClient.cs
+++ b/Withings.NET/Client/WithingsClient.cs
@@ -13,16 +13,17 @@ namespace Withings.NET.Client
     public class WithingsClient
     {
         const string BaseUri = "https://wbsapi.withings.net/v2";
-        readonly ISerializer _serializer;
+
+        private static readonly JsonSerializerOptions _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            Converters = { new ExpandoObjectConverter() }
+        };
+
+        private static readonly ISerializer _serializer = new DefaultJsonSerializer(_jsonOptions);
 
         public WithingsClient(WithingsCredentials credentials)
         {
-            // Enable case-insensitive property name handling for strongly-typed models.
-            // Note: ExpandoObjectConverter ignores PropertyNameCaseInsensitive and always
-            // uses the JSON property names as-is when creating ExpandoObject keys.
-            var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
-            options.Converters.Add(new ExpandoObjectConverter());
-            _serializer = new DefaultJsonSerializer(options);
         }
 
         private IFlurlRequest GetQuery(string path)


### PR DESCRIPTION
💡 **What:** Cached the `JsonSerializerOptions` and `DefaultJsonSerializer` instances as `static readonly` fields in `WithingsClient`.

🎯 **Why:** Creating a new `JsonSerializerOptions` instance for every `WithingsClient` constructor call is inefficient because the options cache reflection metadata for types. This change improves serialization performance and reduces memory allocations, following .NET best practices.

📊 **Measured Improvement:** Due to environment timeouts and slowness, automated benchmarks were not feasible. However, this optimization is a well-documented .NET best practice (e.g., [Microsoft Documentation](https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/configure-options#reuse-jsonserializeroptions-instances)) that prevents redundant metadata generation and memory leaks.

---
*PR created automatically by Jules for task [6147272301614061856](https://jules.google.com/task/6147272301614061856) started by @antarr*